### PR TITLE
Update travis test matrix to use Elixir 1.4.5 and Erlang 20

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,20 @@
 language: elixir
 
 elixir:
-  - 1.2.0
   - 1.3.0
   - 1.3.2
-  - 1.4.0
-  - 1.4.2
+  - 1.4.5
 
 otp_release:
   - 19.3
+  - 20.0
+
+matrix:
+  exclude:
+    - elixir: 1.3.0
+      otp_release: 20.0
+    - elixir: 1.3.2
+      otp_release: 20.0
 
 after_script:
   - MIX_ENV=docs mix deps.get

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 1.0.0 - 7/18/17 Tues
+
+* [BREAKING CHANGE] - Drop support for Elixir 1.2.0. This is done in order to be
+able to easily pattern match on DateTime structs.
+
 ## 0.1.5 - 4/13/17 Thurs
 
 * [ENHANCEMENT] Update to use more idiomatic Elixir code. Thank you [scohen](https://github.com/scohen).

--- a/mix.exs
+++ b/mix.exs
@@ -3,8 +3,8 @@ defmodule NestedFilter.Mixfile do
 
   def project do
     [app: :nested_filter,
-     version: "0.1.5",
-     elixir: ">= 1.2.0",
+     version: "1.0.0",
+     elixir: ">= 1.3.0",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      test_coverage: [tool: ExCoveralls],


### PR DESCRIPTION
And drop support for Elixir 1.2.0 to be able to easily pattern match on
DateTime structs