### PR TITLE
NestedFilter v2.0: structure-preserving core

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,3 @@
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/.github/workflows/nested_filter_ci.yml
+++ b/.github/workflows/nested_filter_ci.yml
@@ -18,12 +18,6 @@ jobs:
       matrix:
         include:
           - pair:
-              elixir: 1.13.x
-              otp: 24.3
-          - pair:
-              elixir: 1.14.x
-              otp: 25.3
-          - pair:
               elixir: 1.15.6
               otp: 26.0.2
           - pair:
@@ -38,6 +32,9 @@ jobs:
           - pair:
               elixir: 1.19.x
               otp: 28.1.1
+          - pair:
+              elixir: 1.20.x
+              otp: 28.1.x
 
     steps:
     - uses: actions/checkout@v6
@@ -58,3 +55,33 @@ jobs:
       run: mix deps.compile
     - name: Run tests
       run: mix test
+
+  quality:
+    name: Quality gate
+    runs-on: ubuntu-22.04
+    env:
+      MIX_ENV: test
+      FORCE_COLOR: 1
+    steps:
+    - uses: actions/checkout@v6
+    - name: Set up Elixir
+      uses: erlef/setup-beam@v1
+      with:
+        otp-version: 28.1.x
+        elixir-version: 1.20.x
+    - name: Restore dependencies cache
+      uses: actions/cache@v5
+      with:
+        path: deps
+        key: mix-quality-${{ runner.os }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: mix-quality-${{ runner.os }}-
+    - name: Install dependencies
+      run: mix deps.get --only test
+    - name: Compile deps
+      run: mix deps.compile
+    - name: Check formatting
+      run: mix format --check-formatted
+    - name: Credo
+      run: mix credo --strict
+    - name: Coverage
+      run: mix coveralls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 2.0.0 - 7/6/26 Monday
+
+-   [BREAKING CHANGE] `take_by_key/3` is now structure-preserving. In 1.x it
+    flattened all matches into a single-level map, silently losing data when
+    the same key appeared in more than one branch. Matches now stay at the
+    path where they were found.
+-   [BREAKING CHANGE] Remove the public-but-undocumented `drop_by/2` and
+    `take_by/2`. Use `reject/3` and `filter/3` instead.
+-   [BREAKING CHANGE] Require Elixir ~> 1.15.
+-   [ENHANCEMENT] New engine functions: `reject/3` recursively removes
+    entries matching a predicate; `filter/3` recursively keeps matching
+    entries (kept whole) and prunes branches without a match.
+    `drop_by_value/3`, `drop_by_key/3`, and `take_by_key/3` are now sugar
+    over the engines and each accept an `opts` argument.
+-   [ENHANCEMENT] New `structs:` option on every function: `:leaf` (default)
+    passes structs through as opaque values, `:convert` recurses into them
+    via `Map.from_struct/1`, `:error` raises `ArgumentError` on any struct.
+-   [ENHANCEMENT] StreamData property suite; 100% test coverage.
+
+### Upgrading from 1.x
+
+| If you used                            | In 2.0                                                                                                    |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `take_by_key(map, keys)`               | Same call, new semantics: results keep their original nesting instead of being flattened (no more data loss on duplicate keys). Audit call sites that relied on a flat result. |
+| `drop_by/2`                            | `reject(map, predicate)` — e.g. `NestedFilter.reject(map, fn _k, v -> is_nil(v) end)`                     |
+| `take_by/2`                            | `filter(map, predicate)` — e.g. `NestedFilter.filter(map, fn k, _v -> k in [:id] end)`                    |
+| Structs converted by hand before 1.x calls | Pass `structs: :convert` (or keep the default `:leaf` to treat structs as opaque values)               |
+| Elixir < 1.15                          | Stay on `nested_filter ~> 1.2` or upgrade Elixir; 2.0 requires `~> 1.15`                                  |
+
 ## 1.2.2 - 5/30/19 Saturday
 
 -   [WARNING FIX] Remove warning from unused parameter (thanks

--- a/README.md
+++ b/README.md
@@ -1,91 +1,126 @@
 # NestedFilter
+
 ![Build](https://github.com/treble37/nested_filter/actions/workflows/nested_filter_ci.yml/badge.svg?branch=main)
-[![Maintainability](https://api.codeclimate.com/v1/badges/ba239c585908a0aad2ac/maintainability)](https://codeclimate.com/github/treble37/nested_filter/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/ba239c585908a0aad2ac/test_coverage)](https://codeclimate.com/github/treble37/nested_filter/test_coverage)
-[![Coverage Status](https://coveralls.io/repos/github/treble37/nested_filter/badge.svg?branch=master)](https://coveralls.io/github/treble37/nested_filter?branch=master)
 [![Hex.pm](https://img.shields.io/hexpm/v/nested_filter.svg)](https://hex.pm/packages/nested_filter)
 [![Hex.pm Downloads](https://img.shields.io/hexpm/dt/nested_filter.svg)](https://hex.pm/packages/nested_filter)
-[![GitHub stars](https://img.shields.io/github/stars/treble37/nested_filter.svg)](https://github.com/treble37/nested_filter/stargazers)
-[![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/treble37/nested_filter/master/LICENSE)
+[![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/treble37/nested_filter/main/LICENSE)
 
-## The Problems
+Structure-preserving filter/reject for nested maps and lists: drop or take
+keys and values at any depth without flattening or losing data. Zero runtime
+dependencies.
 
-1.  You have a nested map (or a struct that you converted to a nested map) and you want to remove ALL the keys with specific values such as nil.
-2.  You want to do a Map#take on a nested map
+`Map.take/2` and `Map.drop/2` only see the top level. NestedFilter walks the
+whole structure — maps inside maps, maps inside lists — and never merges
+sibling branches or invents values: what survives is always at the path where
+it appeared in the input.
 
-##### Example: Remove all the map keys with nil values
+Every example below is copied verbatim from a doctest, so it runs exactly as
+shown.
+
+## Recipes
+
+### Clean params before insert
+
+Drop `nil` and blank values at any depth before handing user input to a
+changeset or query:
 
 ```elixir
-nested_map = %{a: 1, b: %{c: nil, d: nil}, c: nil}
-
-Map.drop(nested_map, [:c, :d])
-# => %{a: 1, b: %{c: nil, d: nil}}
-
-# But you actually wanted:
-# => %{a: 1}
+iex> params = %{"name" => "Ada", "bio" => nil, "address" => %{"city" => "London", "zip" => ""}}
+iex> NestedFilter.drop_by_value(params, [nil, ""])
+%{"name" => "Ada", "address" => %{"city" => "London"}}
 ```
 
-## The Solution: NestedFilter
+### Strip nils before JSON encoding
 
-NestedFilter drills down into a nested map and can do any of the following:
+Remove every `nil` entry so encoded payloads carry no `null` noise:
 
-1.  filters out keys according to user specified values.
-2.  filters out values according to user specified keys.
+```elixir
+iex> payload = %{id: 7, tags: ["a", "b"], meta: %{source: nil, ip: "1.2.3.4"}}
+iex> NestedFilter.reject(payload, fn _k, v -> is_nil(v) end)
+%{id: 7, tags: ["a", "b"], meta: %{ip: "1.2.3.4"}}
+```
+
+### Drop sensitive keys everywhere
+
+Remove known-bad keys wherever they appear, however deeply nested:
+
+```elixir
+iex> event = %{user: %{email: "ada@example.com", password: "s3cret"}, session: %{token: "abc", ttl: 60}}
+iex> NestedFilter.drop_by_key(event, [:password, :token])
+%{user: %{email: "ada@example.com"}, session: %{ttl: 60}}
+```
+
+### Take fields, structure preserved
+
+Keep only the fields you care about without flattening or losing duplicates
+across branches:
+
+```elixir
+iex> order = %{buyer: %{id: 1, name: "Ada"}, items: [%{id: 10, sku: "X"}, %{id: 11, sku: "Y"}]}
+iex> NestedFilter.take_by_key(order, [:id])
+%{buyer: %{id: 1}, items: [%{id: 10}, %{id: 11}]}
+```
+
+### Sanitize logs
+
+Redact by pattern when the exact key names aren't known up front:
+
+```elixir
+iex> log = %{"msg" => "login ok", "user_password" => "hunter2", "ctx" => %{"api_token" => "xyz"}}
+iex> NestedFilter.reject(log, fn k, _v -> is_binary(k) and (k =~ "password" or k =~ "token") end)
+%{"msg" => "login ok", "ctx" => %{}}
+```
 
 ## Installation
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `nested_filter` to your list of dependencies in `mix.exs`:
+Add `nested_filter` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:nested_filter, "~> 1.2.2"}]
+  [{:nested_filter, "~> 2.0"}]
 end
 ```
 
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at <https://hexdocs.pm/nested_filter>.
+Requires Elixir 1.15 or later. Full documentation is at
+[hexdocs.pm/nested_filter](https://hexdocs.pm/nested_filter).
 
-## Usage
+## API
 
-By default, when removing user specified values, empty values will be preserved
-(see Case 1 below). You can add empty values to the user specified values list
-if you wish those "empty values" (e.g., empty maps) to be removed.
+Two engine functions take a `predicate` receiving each key and value:
 
-### NestedFilter.drop_by_value
+- `NestedFilter.reject/3` — recursively remove matching entries
+- `NestedFilter.filter/3` — recursively keep matching entries, pruning
+  branches without a match; a matched entry is kept whole
 
-```elixir
-# Case 1: Remove the nil values from a nested map, preserving empty map values
+Three convenience functions cover the common cases:
 
-nested_map = %{a: 1, b: %{m: nil, n: 2}, c: %{p: %{q: nil, r: nil}, s: %{t: 2, u: 3}} }
-NestedFilter.drop_by_value(nested_map, [nil])
+- `NestedFilter.drop_by_value/3` — remove entries whose value is in a list
+- `NestedFilter.drop_by_key/3` — remove entries whose key is in a list
+- `NestedFilter.take_by_key/3` — keep entries whose key is in a list,
+  structure preserved
 
-# => %{a: 1, b: %{n: 2}, c: %{p: %{}, s: %{t: 2, u: 3}} }
+## Semantics worth knowing
 
-# Case 2: Remove the nil values from a nested map, removing empty map values
+- **Structure is sacred.** Matches stay at the path where they were found.
+  Sibling branches are never merged, so duplicate keys in different branches
+  never clobber each other.
+- **`reject` preserves empty maps; `filter` prunes empty branches.** Rejecting
+  every entry of a nested map leaves `%{}` at its path (add `%{}` to
+  `drop_by_value/3`'s list to remove those too), while `filter` drops any
+  branch with no surviving content.
+- **Lists are traversed, not filtered by value.** `reject` leaves non-map list
+  elements untouched; `filter` prunes list elements with no surviving content.
+- **Structs are opaque leaves by default.** Pass `structs: :convert` to
+  recurse into them as plain maps, or `structs: :error` to raise if one is
+  encountered. See the `:structs` option on `reject/3`.
 
-nested_map = %{a: 1, b: %{m: nil, n: 2}, c: %{p: %{q: nil, r: nil}, s: %{t: 2, u: 3}} }
-NestedFilter.drop_by_value(nested_map, [nil, %{}])
-# => %{a: 1, b: %{n: 2}, c: %{s: %{t: 2, u: 3}} }
-```
+## Upgrading from 1.x
 
-### NestedFilter.drop_by_key
+Version 2.0 changed `take_by_key/3` from flattening (which silently lost data
+on duplicate keys) to structure-preserving, removed the undocumented
+`drop_by/2` and `take_by/2`, and raised the Elixir floor to 1.15. See the
+[CHANGELOG](CHANGELOG.md) for the full migration table.
 
-```elixir
-# Case 1: Remove values from a nested map by key
+## License
 
-nested_map = %{a: 1, b: %{a: 2, b: 3}, c: %{a: %{a: 1, b: 2}, b: 2, c: %{d: 1, e: 2}}}
-assert NestedFilter.drop_by_key(nested_map, [:a]) == %{b: %{b: 3},c: %{b: 2, c: %{d: 1, e: 2}}}
-```
-
-### NestedFilter.take_by_key
-
-```elixir
-# Case 1: Take values from a nested map by key
-
-nested_map = %{a: %{b: 1}, c: 3, e: %{f: 4}}
-assert NestedFilter.take_by_key(nested_map, [:b, :f]) == %{b: 1, f: 4 }
-```
-
-You can browse the tests for more usage examples.
+MIT — see [LICENSE](LICENSE).

--- a/lib/nested_filter.ex
+++ b/lib/nested_filter.ex
@@ -7,6 +7,68 @@ defmodule NestedFilter do
   @type keys_to_select :: list
   @type predicate :: (key, val -> boolean)
 
+  @doc """
+  Recursively removes map entries for which `predicate` returns a truthy value.
+
+  Values are cleaned depth-first: the predicate receives each key and its
+  already-cleaned value. Empty maps produced by rejection are preserved.
+  Lists are traversed, but their non-container elements are untouched — the
+  predicate only applies to map entries, which have keys. Any other input is
+  returned unchanged.
+
+  ## Options
+
+    * `:structs` — how to handle structs encountered at any depth:
+      * `:leaf` (default) — the struct passes through as an opaque value,
+        never recursed into and never altered
+      * `:convert` — the struct is converted with `Map.from_struct/1` and
+        recursed into; the result is a plain map
+      * `:error` — raises `ArgumentError` on any struct
+
+  ## Examples
+
+      iex> NestedFilter.reject(%{a: 1, b: %{c: nil}}, fn _k, v -> is_nil(v) end)
+      %{a: 1, b: %{}}
+
+      iex> NestedFilter.reject(%{a: [1, nil, %{b: nil}]}, fn _k, v -> is_nil(v) end)
+      %{a: [1, nil, %{}]}
+
+  """
+  @spec reject(map | list | any, predicate, keyword) :: map | list | any
+  def reject(data, predicate, opts \\ [])
+
+  def reject(%_{} = struct, predicate, opts) do
+    case Keyword.get(opts, :structs, :leaf) do
+      :leaf ->
+        struct
+
+      :convert ->
+        struct |> Map.from_struct() |> reject(predicate, opts)
+
+      :error ->
+        raise ArgumentError,
+              "encountered struct #{inspect(struct.__struct__)} with structs: :error"
+    end
+  end
+
+  def reject(map, predicate, opts) when is_map(map) do
+    Enum.reduce(map, %{}, fn {key, val}, acc ->
+      cleaned_val = reject(val, predicate, opts)
+
+      if predicate.(key, cleaned_val) do
+        acc
+      else
+        Map.put(acc, key, cleaned_val)
+      end
+    end)
+  end
+
+  def reject(list, predicate, opts) when is_list(list) do
+    Enum.map(list, &reject(&1, predicate, opts))
+  end
+
+  def reject(elem, _predicate, _opts), do: elem
+
   @spec drop_by(struct, predicate) :: struct
   def drop_by(%_{} = struct, _), do: struct
 
@@ -37,21 +99,37 @@ defmodule NestedFilter do
   end
 
   @doc """
-  Take a (nested) map and filter out any keys with specified values in the
-  values_to_reject list.
+  Recursively removes map entries whose value is in `values_to_reject`.
+
+  Sugar for `reject(map, fn _key, val -> val in values_to_reject end, opts)` —
+  see `reject/3` for the traversal semantics and options.
+
+  ## Examples
+
+      iex> NestedFilter.drop_by_value(%{a: 1, b: %{m: nil, n: 2}}, [nil])
+      %{a: 1, b: %{n: 2}}
+
   """
-  @spec drop_by_value(%{any => any}, [any]) :: %{any => any}
-  def drop_by_value(map, values_to_reject) when is_map(map) do
-    drop_by(map, fn _, val -> val in values_to_reject end)
+  @spec drop_by_value(map, [val], keyword) :: map
+  def drop_by_value(map, values_to_reject, opts \\ []) when is_map(map) do
+    reject(map, fn _key, val -> val in values_to_reject end, opts)
   end
 
   @doc """
-  Take a (nested) map and filter out any values with specified keys in the
-  keys_to_reject list.
+  Recursively removes map entries whose key is in `keys_to_reject`.
+
+  Sugar for `reject(map, fn key, _val -> key in keys_to_reject end, opts)` —
+  see `reject/3` for the traversal semantics and options.
+
+  ## Examples
+
+      iex> NestedFilter.drop_by_key(%{a: 1, b: %{a: 2, c: 3}}, [:a])
+      %{b: %{c: 3}}
+
   """
-  @spec drop_by_key(%{any => any}, [any]) :: %{any => any}
-  def drop_by_key(map, keys_to_reject) when is_map(map) do
-    drop_by(map, fn key, _ -> key in keys_to_reject end)
+  @spec drop_by_key(map, [key], keyword) :: map
+  def drop_by_key(map, keys_to_reject, opts \\ []) when is_map(map) do
+    reject(map, fn key, _val -> key in keys_to_reject end, opts)
   end
 
   @spec take_by(map, keys_to_select) :: map

--- a/lib/nested_filter.ex
+++ b/lib/nested_filter.ex
@@ -1,6 +1,21 @@
 defmodule NestedFilter do
   @moduledoc """
-  Documentation for NestedFilter.
+  Structure-preserving filtering for nested maps and lists.
+
+  Two engine functions traverse arbitrarily nested maps and lists with
+  a predicate:
+
+    * `reject/3` — recursively remove matching entries
+    * `filter/3` — recursively keep matching entries, pruning branches
+      without a match
+
+  Three convenience functions cover the common cases: `drop_by_value/3`,
+  `drop_by_key/3`, and `take_by_key/3`.
+
+  No operation ever merges sibling branches or invents values — what
+  survives is always at the path where it appeared in the input. Structs
+  are treated as opaque leaf values by default; see the `:structs` option
+  on `reject/3`.
   """
   @type key :: any
   @type val :: any
@@ -170,35 +185,6 @@ defmodule NestedFilter do
           "encountered struct #{inspect(struct.__struct__)} with structs: :error"
   end
 
-  @spec drop_by(struct, predicate) :: struct
-  def drop_by(%_{} = struct, _), do: struct
-
-  @spec drop_by(map, predicate) :: map
-  def drop_by(map, predicate) when is_map(map) do
-    map
-    |> Enum.reduce(
-      %{},
-      fn {key, val}, acc ->
-        cleaned_val = drop_by(val, predicate)
-
-        if predicate.(key, cleaned_val) do
-          acc
-        else
-          Map.put(acc, key, cleaned_val)
-        end
-      end
-    )
-  end
-
-  @spec drop_by(list, predicate) :: list
-  def drop_by(list, predicate) when is_list(list) do
-    Enum.map(list, &drop_by(&1, predicate))
-  end
-
-  def drop_by(elem, _) do
-    elem
-  end
-
   @doc """
   Recursively removes map entries whose value is in `values_to_reject`.
 
@@ -231,22 +217,6 @@ defmodule NestedFilter do
   @spec drop_by_key(map, [key], keyword) :: map
   def drop_by_key(map, keys_to_reject, opts \\ []) when is_map(map) do
     reject(map, fn key, _val -> key in keys_to_reject end, opts)
-  end
-
-  @spec take_by(map, keys_to_select) :: map
-  def take_by(map, keys_to_select) when is_map(map) do
-    map
-    |> Enum.reduce(
-      %{},
-      fn {_key, val}, acc ->
-        Map.merge(acc, take_by(val, keys_to_select))
-      end
-    )
-    |> Map.merge(Map.take(map, keys_to_select))
-  end
-
-  def take_by(_elem, _) do
-    %{}
   end
 
   @doc """

--- a/lib/nested_filter.ex
+++ b/lib/nested_filter.ex
@@ -250,14 +250,28 @@ defmodule NestedFilter do
   end
 
   @doc """
-  Take a (nested) map and keep any values with specified keys in the
-  keys_to_select list.
+  Recursively keeps map entries whose key is in `keys_to_select`,
+  preserving the structure they were found in.
+
+  Sugar for `filter(map, fn key, _val -> key in keys_to_select end, opts)` —
+  see `filter/3` for the traversal semantics and options. Matches stay at
+  the path where they were found; sibling branches are never merged, and
+  branches without a match are pruned.
+
+  > #### Changed in 2.0 {: .warning}
+  >
+  > In 1.x this function flattened all matches into a single-level map,
+  > silently losing data when the same key appeared in more than one
+  > branch. It is now structure-preserving.
+
+  ## Examples
+
+      iex> NestedFilter.take_by_key(%{a: %{x: 1}, b: %{x: 2}}, [:x])
+      %{a: %{x: 1}, b: %{x: 2}}
+
   """
-  @spec take_by_key(%{any => any}, [any]) :: %{any => any}
-  def take_by_key(map, keys_to_select) when is_map(map) do
-    Map.merge(
-      take_by(map, keys_to_select),
-      Map.take(map, keys_to_select)
-    )
+  @spec take_by_key(map, keys_to_select, keyword) :: map
+  def take_by_key(map, keys_to_select, opts \\ []) when is_map(map) do
+    filter(map, fn key, _val -> key in keys_to_select end, opts)
   end
 end

--- a/lib/nested_filter.ex
+++ b/lib/nested_filter.ex
@@ -16,6 +16,50 @@ defmodule NestedFilter do
   survives is always at the path where it appeared in the input. Structs
   are treated as opaque leaf values by default; see the `:structs` option
   on `reject/3`.
+
+  ## Recipes
+
+  ### Clean params before insert
+
+  Drop `nil` and blank values at any depth before handing user input to a
+  changeset or query:
+
+      iex> params = %{"name" => "Ada", "bio" => nil, "address" => %{"city" => "London", "zip" => ""}}
+      iex> NestedFilter.drop_by_value(params, [nil, ""])
+      %{"name" => "Ada", "address" => %{"city" => "London"}}
+
+  ### Strip nils before JSON encoding
+
+  Remove every `nil` entry so encoded payloads carry no `null` noise:
+
+      iex> payload = %{id: 7, tags: ["a", "b"], meta: %{source: nil, ip: "1.2.3.4"}}
+      iex> NestedFilter.reject(payload, fn _k, v -> is_nil(v) end)
+      %{id: 7, tags: ["a", "b"], meta: %{ip: "1.2.3.4"}}
+
+  ### Drop sensitive keys everywhere
+
+  Remove known-bad keys wherever they appear, however deeply nested:
+
+      iex> event = %{user: %{email: "ada@example.com", password: "s3cret"}, session: %{token: "abc", ttl: 60}}
+      iex> NestedFilter.drop_by_key(event, [:password, :token])
+      %{user: %{email: "ada@example.com"}, session: %{ttl: 60}}
+
+  ### Take fields, structure preserved
+
+  Keep only the fields you care about without flattening or losing
+  duplicates across branches:
+
+      iex> order = %{buyer: %{id: 1, name: "Ada"}, items: [%{id: 10, sku: "X"}, %{id: 11, sku: "Y"}]}
+      iex> NestedFilter.take_by_key(order, [:id])
+      %{buyer: %{id: 1}, items: [%{id: 10}, %{id: 11}]}
+
+  ### Sanitize logs
+
+  Redact by pattern when the exact key names aren't known up front:
+
+      iex> log = %{"msg" => "login ok", "user_password" => "hunter2", "ctx" => %{"api_token" => "xyz"}}
+      iex> NestedFilter.reject(log, fn k, _v -> is_binary(k) and (k =~ "password" or k =~ "token") end)
+      %{"msg" => "login ok", "ctx" => %{}}
   """
   @type key :: any
   @type val :: any

--- a/lib/nested_filter.ex
+++ b/lib/nested_filter.ex
@@ -46,8 +46,7 @@ defmodule NestedFilter do
         struct |> Map.from_struct() |> reject(predicate, opts)
 
       :error ->
-        raise ArgumentError,
-              "encountered struct #{inspect(struct.__struct__)} with structs: :error"
+        struct_error!(struct)
     end
   end
 
@@ -68,6 +67,108 @@ defmodule NestedFilter do
   end
 
   def reject(elem, _predicate, _opts), do: elem
+
+  @doc """
+  Recursively keeps map entries for which `predicate` returns a truthy value.
+
+  A matched entry is kept whole: its value is not recursed into, so the
+  entire subtree survives. A container entry (map or list) that is not
+  matched itself is kept only if it has surviving descendants; branches and
+  list elements with no surviving content are pruned entirely. Any other
+  input is returned unchanged.
+
+  Structure is always preserved — matches stay at the path where they were
+  found, and sibling branches are never merged.
+
+  ## Options
+
+  Accepts the same `:structs` option as `reject/3`. With the default
+  `:leaf`, a struct is an opaque value: kept whole when its entry is
+  matched, pruned otherwise.
+
+  ## Examples
+
+      iex> NestedFilter.filter(
+      ...>   %{a: %{x: 1}, b: %{y: 2}, c: [%{x: 3, y: 4}, %{y: 5}]},
+      ...>   fn k, _v -> k in [:x] end
+      ...> )
+      %{a: %{x: 1}, c: [%{x: 3}]}
+
+      iex> NestedFilter.filter(%{user: %{name: "ada"}, meta: %{z: 1}}, fn k, _v -> k == :user end)
+      %{user: %{name: "ada"}}
+
+  """
+  @spec filter(map | list | any, predicate, keyword) :: map | list | any
+  def filter(data, predicate, opts \\ [])
+
+  def filter(%_{} = struct, predicate, opts) do
+    case Keyword.get(opts, :structs, :leaf) do
+      :leaf -> struct
+      :convert -> struct |> Map.from_struct() |> filter(predicate, opts)
+      :error -> struct_error!(struct)
+    end
+  end
+
+  def filter(map, predicate, opts) when is_map(map) do
+    Enum.reduce(map, %{}, fn {key, val}, acc ->
+      filter_entry(acc, key, val, predicate, opts)
+    end)
+  end
+
+  def filter(list, predicate, opts) when is_list(list) do
+    Enum.flat_map(list, fn elem ->
+      case filter_value(elem, predicate, opts) do
+        {:keep, kept} -> [kept]
+        :prune -> []
+      end
+    end)
+  end
+
+  def filter(elem, _predicate, _opts), do: elem
+
+  # A matched entry is kept whole; an unmatched one survives only if
+  # filtering its value leaves surviving content.
+  defp filter_entry(acc, key, val, predicate, opts) do
+    if predicate.(key, val) do
+      Map.put(acc, key, val)
+    else
+      case filter_value(val, predicate, opts) do
+        {:keep, kept} -> Map.put(acc, key, kept)
+        :prune -> acc
+      end
+    end
+  end
+
+  # Filters an unmatched value: containers survive only with surviving
+  # content; everything else is pruned.
+  defp filter_value(%_{} = struct, predicate, opts) do
+    case Keyword.get(opts, :structs, :leaf) do
+      :leaf -> :prune
+      :convert -> struct |> Map.from_struct() |> filter_value(predicate, opts)
+      :error -> struct_error!(struct)
+    end
+  end
+
+  defp filter_value(map, predicate, opts) when is_map(map) do
+    case filter(map, predicate, opts) do
+      filtered when map_size(filtered) == 0 -> :prune
+      filtered -> {:keep, filtered}
+    end
+  end
+
+  defp filter_value(list, predicate, opts) when is_list(list) do
+    case filter(list, predicate, opts) do
+      [] -> :prune
+      filtered -> {:keep, filtered}
+    end
+  end
+
+  defp filter_value(_elem, _predicate, _opts), do: :prune
+
+  defp struct_error!(struct) do
+    raise ArgumentError,
+          "encountered struct #{inspect(struct.__struct__)} with structs: :error"
+  end
 
   @spec drop_by(struct, predicate) :: struct
   def drop_by(%_{} = struct, _), do: struct

--- a/lib/nested_filter.ex
+++ b/lib/nested_filter.ex
@@ -5,7 +5,7 @@ defmodule NestedFilter do
   @type key :: any
   @type val :: any
   @type keys_to_select :: list
-  @type predicate :: ((key, val) -> boolean)
+  @type predicate :: (key, val -> boolean)
 
   @spec drop_by(struct, predicate) :: struct
   def drop_by(%_{} = struct, _), do: struct
@@ -13,15 +13,18 @@ defmodule NestedFilter do
   @spec drop_by(map, predicate) :: map
   def drop_by(map, predicate) when is_map(map) do
     map
-    |> Enum.reduce(%{},
-    fn ({key, val}, acc) ->
-      cleaned_val = drop_by(val, predicate)
-      if predicate.(key, cleaned_val) do
-        acc
-      else
-        Map.put(acc, key, cleaned_val)
+    |> Enum.reduce(
+      %{},
+      fn {key, val}, acc ->
+        cleaned_val = drop_by(val, predicate)
+
+        if predicate.(key, cleaned_val) do
+          acc
+        else
+          Map.put(acc, key, cleaned_val)
+        end
       end
-    end)
+    )
   end
 
   @spec drop_by(list, predicate) :: list
@@ -39,7 +42,7 @@ defmodule NestedFilter do
   """
   @spec drop_by_value(%{any => any}, [any]) :: %{any => any}
   def drop_by_value(map, values_to_reject) when is_map(map) do
-    drop_by(map, fn (_, val) -> val in values_to_reject end)
+    drop_by(map, fn _, val -> val in values_to_reject end)
   end
 
   @doc """
@@ -48,18 +51,19 @@ defmodule NestedFilter do
   """
   @spec drop_by_key(%{any => any}, [any]) :: %{any => any}
   def drop_by_key(map, keys_to_reject) when is_map(map) do
-    drop_by(map, fn(key, _) -> key in keys_to_reject end)
+    drop_by(map, fn key, _ -> key in keys_to_reject end)
   end
 
   @spec take_by(map, keys_to_select) :: map
   def take_by(map, keys_to_select) when is_map(map) do
     map
-    |> Enum.reduce(%{},
-    fn ({_key, val}, acc) ->
-      Map.merge(acc, take_by(val, keys_to_select))
-    end)
-    |>
-    Map.merge(Map.take(map, keys_to_select))
+    |> Enum.reduce(
+      %{},
+      fn {_key, val}, acc ->
+        Map.merge(acc, take_by(val, keys_to_select))
+      end
+    )
+    |> Map.merge(Map.take(map, keys_to_select))
   end
 
   def take_by(_elem, _) do
@@ -74,6 +78,7 @@ defmodule NestedFilter do
   def take_by_key(map, keys_to_select) when is_map(map) do
     Map.merge(
       take_by(map, keys_to_select),
-      Map.take(map, keys_to_select))
+      Map.take(map, keys_to_select)
+    )
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,17 +1,22 @@
 defmodule NestedFilter.Mixfile do
   use Mix.Project
 
+  @version "2.0.0"
+  @source_url "https://github.com/treble37/nested_filter"
+
   def project do
     [
       app: :nested_filter,
-      version: "2.0.0",
+      version: @version,
       elixir: "~> 1.15",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       test_coverage: [tool: ExCoveralls],
       description: description(),
       package: package(),
-      deps: deps()
+      deps: deps(),
+      source_url: @source_url,
+      docs: [source_ref: "v#{@version}"]
     ]
   end
 
@@ -20,7 +25,7 @@ defmodule NestedFilter.Mixfile do
       files: ["lib", "mix.exs", "README*", "LICENSE*"],
       maintainers: ["Bruce Park"],
       licenses: ["MIT"],
-      links: %{"GitHub" => "https://github.com/treble37/nested_filter"}
+      links: %{"GitHub" => @source_url}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,8 +4,8 @@ defmodule NestedFilter.Mixfile do
   def project do
     [
       app: :nested_filter,
-      version: "1.2.2",
-      elixir: ">= 1.9.0",
+      version: "2.0.0",
+      elixir: "~> 1.15",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       test_coverage: [tool: ExCoveralls],
@@ -26,8 +26,9 @@ defmodule NestedFilter.Mixfile do
 
   defp description do
     """
-    Drill down into a nested map and filter out keys according to user
-    specified values
+    Structure-preserving filter/reject for nested maps and lists: drop or
+    take keys and values at any depth without flattening or losing data.
+    Zero runtime dependencies.
     """
   end
 
@@ -52,7 +53,8 @@ defmodule NestedFilter.Mixfile do
     [
       {:ex_doc, ">= 0.40.0", only: :dev},
       {:excoveralls, "~> 0.18.5", only: :test},
-      {:credo, "~> 1.7.0", only: [:dev, :test]}
+      {:credo, "~> 1.7.0", only: [:dev, :test]},
+      {:stream_data, "~> 1.1", only: [:test, :dev]}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -22,5 +22,6 @@
   "parse_trans": {:hex, :parse_trans, "3.4.1", "6e6aa8167cb44cc8f39441d05193be6e6f4e7c2946cb2759f015f8c56b76e5ff", [:rebar3], [], "hexpm", "620a406ce75dada827b82e453c19cf06776be266f5a67cff34e1ef2cbb60e49a"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.7", "354c321cf377240c7b8716899e182ce4890c5938111a1296add3ec74cf1715df", [:make, :mix, :rebar3], [], "hexpm", "fe4c190e8f37401d30167c8c405eda19469f34577987c76dde613e838bbc67f8"},
+  "stream_data": {:hex, :stream_data, "1.3.0", "bde37905530aff386dea1ddd86ecbf00e6642dc074ceffc10b7d4e41dfd6aac9", [:mix], [], "hexpm", "3cc552e286e817dca43c98044c706eec9318083a1480c52ae2688b08e2936e3c"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
 }

--- a/test/nested_filter_property_test.exs
+++ b/test/nested_filter_property_test.exs
@@ -1,0 +1,174 @@
+defmodule NestedFilterPropertyTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  defmodule Point do
+    defstruct [:x, :y]
+  end
+
+  property "reject/3 output contains no entry matching the predicate at any depth" do
+    check all({term, predicate} <- term_with_predicate(scalar_gen())) do
+      term
+      |> NestedFilter.reject(predicate)
+      |> refute_match_anywhere(predicate)
+    end
+  end
+
+  property "filter/3 invents nothing: every output leaf exists at the same path in the input" do
+    check all({term, predicate} <- term_with_predicate(scalar_gen())) do
+      output_leaves = term |> NestedFilter.filter(predicate) |> leaf_paths() |> Enum.frequencies()
+      input_leaves = term |> leaf_paths() |> Enum.frequencies()
+
+      Enum.each(output_leaves, fn {leaf_at_path, count} ->
+        assert Map.get(input_leaves, leaf_at_path, 0) >= count
+      end)
+    end
+  end
+
+  property "reject/3 and filter/3 are idempotent" do
+    check all({term, predicate} <- term_with_predicate(scalar_gen())) do
+      rejected = NestedFilter.reject(term, predicate)
+      assert NestedFilter.reject(rejected, predicate) == rejected
+
+      filtered = NestedFilter.filter(term, predicate)
+      assert NestedFilter.filter(filtered, predicate) == filtered
+    end
+  end
+
+  property "structs: :leaf round-trips structs unchanged" do
+    check all({term, predicate} <- term_with_predicate(one_of([scalar_gen(), struct_gen()]))) do
+      input_structs = all_structs(term)
+
+      for engine <- [&NestedFilter.reject/3, &NestedFilter.filter/3] do
+        output_structs = all_structs(engine.(term, predicate, structs: :leaf))
+        assert output_structs -- input_structs == []
+      end
+
+      assert NestedFilter.reject(term, fn _k, _v -> false end) == term
+    end
+  end
+
+  # --- Generators -----------------------------------------------------------
+
+  defp key_gen do
+    one_of([atom(:alphanumeric), string(:alphanumeric, max_length: 8)])
+  end
+
+  defp scalar_gen do
+    one_of([integer(), boolean(), string(:alphanumeric, max_length: 8), constant(nil)])
+  end
+
+  defp struct_gen do
+    gen all(x <- integer(), y <- integer()) do
+      %Point{x: x, y: y}
+    end
+  end
+
+  # Bounded-depth JSON-shaped terms: nested maps and lists over the given
+  # leaves, with mixed atom and string keys.
+  defp nested_gen(leaf_gen) do
+    tree(leaf_gen, fn child ->
+      one_of([
+        map_of(key_gen(), child, max_length: 4),
+        list_of(child, max_length: 4)
+      ])
+    end)
+  end
+
+  # A term paired with a key- or value-based predicate whose targets are
+  # drawn from the term itself (plus noise), so matches actually happen.
+  defp term_with_predicate(leaf_gen) do
+    gen all(
+          term <- nested_gen(leaf_gen),
+          kind <- member_of([:key, :value]),
+          targets <- targets_gen(term, kind)
+        ) do
+      predicate =
+        case kind do
+          :key -> fn key, _val -> key in targets end
+          :value -> fn _key, val -> val in targets end
+        end
+
+      {term, predicate}
+    end
+  end
+
+  defp targets_gen(term, :key) do
+    term |> all_keys() |> Enum.uniq() |> sublist_gen(key_gen())
+  end
+
+  defp targets_gen(term, :value) do
+    term |> all_scalars() |> Enum.uniq() |> sublist_gen(scalar_gen())
+  end
+
+  defp sublist_gen([], noise_gen), do: list_of(noise_gen, max_length: 2)
+
+  defp sublist_gen(present, noise_gen) do
+    gen all(
+          sampled <- list_of(member_of(present), max_length: 3),
+          noise <- list_of(noise_gen, max_length: 1)
+        ) do
+      Enum.uniq(sampled ++ noise)
+    end
+  end
+
+  # --- Walkers (structs are opaque leaves throughout) -----------------------
+
+  defp refute_match_anywhere(%_{}, _predicate), do: :ok
+
+  defp refute_match_anywhere(map, predicate) when is_map(map) do
+    Enum.each(map, fn {key, val} ->
+      refute predicate.(key, val)
+      refute_match_anywhere(val, predicate)
+    end)
+  end
+
+  defp refute_match_anywhere(list, predicate) when is_list(list) do
+    Enum.each(list, &refute_match_anywhere(&1, predicate))
+  end
+
+  defp refute_match_anywhere(_scalar, _predicate), do: :ok
+
+  defp leaf_paths(term), do: leaf_paths(term, [])
+
+  defp leaf_paths(%_{} = struct, path), do: [{Enum.reverse(path), struct}]
+
+  defp leaf_paths(map, path) when is_map(map) do
+    Enum.flat_map(map, fn {key, val} -> leaf_paths(val, [{:key, key} | path]) end)
+  end
+
+  # List positions are recorded without their index: filter/3 prunes list
+  # elements, shifting the indices of the survivors.
+  defp leaf_paths(list, path) when is_list(list) do
+    Enum.flat_map(list, &leaf_paths(&1, [:list | path]))
+  end
+
+  defp leaf_paths(scalar, path), do: [{Enum.reverse(path), scalar}]
+
+  defp all_keys(%_{}), do: []
+
+  defp all_keys(map) when is_map(map) do
+    Enum.flat_map(map, fn {key, val} -> [key | all_keys(val)] end)
+  end
+
+  defp all_keys(list) when is_list(list), do: Enum.flat_map(list, &all_keys/1)
+  defp all_keys(_scalar), do: []
+
+  defp all_scalars(%_{}), do: []
+
+  defp all_scalars(map) when is_map(map) do
+    Enum.flat_map(map, fn {_key, val} -> all_scalars(val) end)
+  end
+
+  defp all_scalars(list) when is_list(list), do: Enum.flat_map(list, &all_scalars/1)
+  defp all_scalars(scalar), do: [scalar]
+
+  defp all_structs(%_{} = struct), do: [struct]
+
+  defp all_structs(map) when is_map(map) do
+    Enum.flat_map(map, fn {_key, val} -> all_structs(val) end)
+  end
+
+  defp all_structs(list) when is_list(list), do: Enum.flat_map(list, &all_structs/1)
+  defp all_structs(_scalar), do: []
+end

--- a/test/nested_filter_test.exs
+++ b/test/nested_filter_test.exs
@@ -254,26 +254,40 @@ defmodule NestedFilterTest do
     end
   end
 
-  test "take a nested map's values by key (distinct nested keys)" do
-    nested_map = %{a: %{b: 2}, c: %{d: 3, e: %{f: 4, g: %{h: %{1 => 2}}}}}
+  describe "take_by_key/3 (structure-preserving)" do
+    test "no flattening, no data loss on key collisions across branches" do
+      nested_map = %{a: %{x: 1}, b: %{x: 2}}
+      assert NestedFilter.take_by_key(nested_map, [:x]) == %{a: %{x: 1}, b: %{x: 2}}
+    end
 
-    assert NestedFilter.take_by_key(nested_map, [:b, :f, :h]) ==
-             %{b: 2, f: 4, h: %{1 => 2}}
-  end
+    test "keeps matches at the path where they were found" do
+      nested_map = %{a: %{b: 2}, c: %{d: 3, e: %{f: 4, g: %{h: %{1 => 2}}}}}
 
-  test "take a nested map's values by key and merges map values of duplicate keys" do
-    nested_map = %{a: 1, b: %{a: 2, b: 3}, c: %{a: %{a: 1, b: 2}, b: 2, c: %{d: 1, e: 2}}}
+      assert NestedFilter.take_by_key(nested_map, [:b, :f, :h]) ==
+               %{a: %{b: 2}, c: %{e: %{f: 4, g: %{h: %{1 => 2}}}}}
+    end
 
-    assert NestedFilter.take_by_key(nested_map, [:b, :c]) == %{
-             b: %{b: 3, a: 2},
-             c: %{b: 2, c: %{d: 1, e: 2}, a: %{a: 1, b: 2}}
-           }
-  end
+    test "matched entries are kept whole, including nested duplicates" do
+      nested_map = %{a: 1, b: %{a: 2, b: 3}, c: %{a: %{a: 1, b: 2}, b: 2, c: %{d: 1, e: 2}}}
 
-  test "take a nested map's values by key (duplicate keys) and overwrite non-map duplicate values" do
-    nested_map = %{a: %{b: 2}, c: 3, e: %{f: 4}, b: 1}
+      assert NestedFilter.take_by_key(nested_map, [:b, :c]) == %{
+               b: %{a: 2, b: 3},
+               c: %{a: %{a: 1, b: 2}, b: 2, c: %{d: 1, e: 2}}
+             }
+    end
 
-    assert NestedFilter.take_by_key(nested_map, [:b, :f]) ==
-             %{b: 1, f: 4}
+    test "keys matched at different depths survive independently" do
+      nested_map = %{a: %{b: 2}, c: 3, e: %{f: 4}, b: 1}
+
+      assert NestedFilter.take_by_key(nested_map, [:b, :f]) ==
+               %{a: %{b: 2}, b: 1, e: %{f: 4}}
+    end
+
+    test "forwards the structs option" do
+      nested_map = %{user: %Profile{name: "ada", email: nil}}
+
+      assert NestedFilter.take_by_key(nested_map, [:name], structs: :convert) ==
+               %{user: %{name: "ada"}}
+    end
   end
 end

--- a/test/nested_filter_test.exs
+++ b/test/nested_filter_test.exs
@@ -1,6 +1,12 @@
+defmodule NestedFilterTest.Profile do
+  defstruct [:name, :email]
+end
+
 defmodule NestedFilterTest do
   use ExUnit.Case
   doctest NestedFilter
+
+  alias NestedFilterTest.Profile
 
   test "can filter out a nested map's keys with nil values" do
     nested_map = %{a: 1, b: %{m: nil, n: 2}, c: %{p: %{q: nil, r: nil}, s: %{t: 2, u: 3}}}
@@ -90,6 +96,85 @@ defmodule NestedFilterTest do
     list = [%{a: 1, b: 2}, %{a: 1, b: 2}]
     nested_map = %{list: list}
     assert NestedFilter.drop_by_key(nested_map, [:b]) == %{list: [%{a: 1}, %{a: 1}]}
+  end
+
+  describe "reject/3" do
+    test "removes entries matching the predicate at any depth, preserving empty maps" do
+      nested_map = %{a: 1, b: %{m: nil, n: 2}, c: %{p: %{q: nil, r: nil}}}
+
+      assert NestedFilter.reject(nested_map, fn _k, v -> is_nil(v) end) ==
+               %{a: 1, b: %{n: 2}, c: %{p: %{}}}
+    end
+
+    test "predicate receives the already-cleaned value" do
+      nested_map = %{a: %{b: nil}}
+
+      assert NestedFilter.reject(nested_map, fn _k, v -> is_nil(v) or v == %{} end) == %{}
+    end
+
+    test "non-container list elements are untouched" do
+      nested_map = %{a: [1, nil, %{b: nil, c: 2}]}
+
+      assert NestedFilter.reject(nested_map, fn _k, v -> is_nil(v) end) ==
+               %{a: [1, nil, %{c: 2}]}
+    end
+
+    test "structs are leaves by default: never entered, never altered" do
+      profile = %Profile{name: "ada", email: nil}
+      nested_map = %{user: profile, junk: nil}
+
+      assert NestedFilter.reject(nested_map, fn _k, v -> is_nil(v) end) ==
+               %{user: profile}
+    end
+
+    test "a bare struct passes through unchanged" do
+      profile = %Profile{name: "ada", email: nil}
+      assert NestedFilter.reject(profile, fn _k, v -> is_nil(v) end) == profile
+    end
+
+    test "structs: :convert recurses into the struct as a plain map" do
+      nested_map = %{user: %Profile{name: "ada", email: nil}}
+
+      assert NestedFilter.reject(nested_map, fn _k, v -> is_nil(v) end, structs: :convert) ==
+               %{user: %{name: "ada"}}
+    end
+
+    test "structs: :error raises ArgumentError naming the struct module" do
+      nested_map = %{user: %Profile{name: "ada", email: nil}}
+
+      assert_raise ArgumentError, ~r/NestedFilterTest\.Profile/, fn ->
+        NestedFilter.reject(nested_map, fn _k, v -> is_nil(v) end, structs: :error)
+      end
+    end
+
+    test "non-map, non-list input is returned unchanged" do
+      assert NestedFilter.reject(5, fn _k, v -> is_nil(v) end) == 5
+      assert NestedFilter.reject("hello", fn _k, v -> is_nil(v) end) == "hello"
+      assert NestedFilter.reject(nil, fn _k, v -> is_nil(v) end) == nil
+    end
+
+    test "mixed atom and string keys are compared with plain equality" do
+      nested_map = %{"a" => 1, :a => 2, "b" => %{"a" => 3}}
+
+      assert NestedFilter.reject(nested_map, fn k, _v -> k == "a" end) ==
+               %{:a => 2, "b" => %{}}
+    end
+  end
+
+  describe "drop sugar with opts" do
+    test "drop_by_value/3 forwards the structs option" do
+      nested_map = %{user: %Profile{name: "ada", email: nil}}
+
+      assert NestedFilter.drop_by_value(nested_map, [nil], structs: :convert) ==
+               %{user: %{name: "ada"}}
+    end
+
+    test "drop_by_key/3 forwards the structs option" do
+      nested_map = %{user: %Profile{name: "ada", email: "a@b.c"}}
+
+      assert NestedFilter.drop_by_key(nested_map, [:email], structs: :convert) ==
+               %{user: %{name: "ada"}}
+    end
   end
 
   test "take a nested map's values by key (distinct nested keys)" do

--- a/test/nested_filter_test.exs
+++ b/test/nested_filter_test.exs
@@ -238,6 +238,11 @@ defmodule NestedFilterTest do
 
       assert NestedFilter.filter(nested_map, fn k, _v -> k == :name end, structs: :convert) ==
                %{user: %{name: "ada"}}
+
+      bare_struct = %Profile{name: "ada", email: nil}
+
+      assert NestedFilter.filter(bare_struct, fn k, _v -> k == :name end, structs: :convert) ==
+               %{name: "ada"}
     end
 
     test "structs: :error raises ArgumentError naming the struct module" do
@@ -245,6 +250,10 @@ defmodule NestedFilterTest do
 
       assert_raise ArgumentError, ~r/NestedFilterTest\.Profile/, fn ->
         NestedFilter.filter(nested_map, fn k, _v -> k == :name end, structs: :error)
+      end
+
+      assert_raise ArgumentError, ~r/NestedFilterTest\.Profile/, fn ->
+        NestedFilter.filter(%Profile{name: "ada"}, fn k, _v -> k == :name end, structs: :error)
       end
     end
 

--- a/test/nested_filter_test.exs
+++ b/test/nested_filter_test.exs
@@ -177,6 +177,83 @@ defmodule NestedFilterTest do
     end
   end
 
+  describe "filter/3" do
+    test "keeps matched entries and containers with surviving descendants, pruning the rest" do
+      nested_map = %{a: %{x: 1}, b: %{y: 2}, c: [%{x: 3, y: 4}, %{y: 5}]}
+
+      assert NestedFilter.filter(nested_map, fn k, _v -> k in [:x] end) ==
+               %{a: %{x: 1}, c: [%{x: 3}]}
+    end
+
+    test "matched entries are kept whole: no recursion into a matched value" do
+      nested_map = %{user: %{name: "ada", password: "secret"}, meta: %{z: 1}}
+
+      assert NestedFilter.filter(nested_map, fn k, _v -> k == :user end) ==
+               %{user: %{name: "ada", password: "secret"}}
+    end
+
+    test "no cross-branch merging or data loss on key collisions" do
+      nested_map = %{a: %{x: 1}, b: %{x: 2}}
+      assert NestedFilter.filter(nested_map, fn k, _v -> k in [:x] end) == nested_map
+    end
+
+    test "branches with no surviving content are pruned entirely" do
+      nested_map = %{a: %{b: %{c: 1}}, d: 2}
+      assert NestedFilter.filter(nested_map, fn k, _v -> k == :nope end) == %{}
+    end
+
+    test "non-container list elements with no surviving content are pruned" do
+      nested_map = %{c: [1, "two", %{x: 3}]}
+      assert NestedFilter.filter(nested_map, fn k, _v -> k == :x end) == %{c: [%{x: 3}]}
+    end
+
+    test "a top-level list is traversed symmetrically" do
+      list = [%{x: 1}, %{y: 2}, 3]
+      assert NestedFilter.filter(list, fn k, _v -> k == :x end) == [%{x: 1}]
+    end
+
+    test "mixed atom and string keys are compared with plain equality" do
+      nested_map = %{"x" => 1, :x => 2, "b" => %{"x" => 3}, "c" => %{y: 4}}
+
+      assert NestedFilter.filter(nested_map, fn k, _v -> k == "x" end) ==
+               %{"x" => 1, "b" => %{"x" => 3}}
+    end
+
+    test "structs are leaves by default: kept whole when matched, pruned when not" do
+      profile = %Profile{name: "ada", email: nil}
+
+      assert NestedFilter.filter(%{user: profile, other: 1}, fn k, _v -> k == :user end) ==
+               %{user: profile}
+
+      assert NestedFilter.filter(%{user: profile}, fn k, _v -> k == :nope end) == %{}
+    end
+
+    test "a bare struct passes through unchanged" do
+      profile = %Profile{name: "ada", email: nil}
+      assert NestedFilter.filter(profile, fn k, _v -> k == :name end) == profile
+    end
+
+    test "structs: :convert recurses into the struct as a plain map" do
+      nested_map = %{user: %Profile{name: "ada", email: nil}}
+
+      assert NestedFilter.filter(nested_map, fn k, _v -> k == :name end, structs: :convert) ==
+               %{user: %{name: "ada"}}
+    end
+
+    test "structs: :error raises ArgumentError naming the struct module" do
+      nested_map = %{user: %Profile{name: "ada", email: nil}}
+
+      assert_raise ArgumentError, ~r/NestedFilterTest\.Profile/, fn ->
+        NestedFilter.filter(nested_map, fn k, _v -> k == :name end, structs: :error)
+      end
+    end
+
+    test "non-map, non-list input is returned unchanged" do
+      assert NestedFilter.filter(5, fn k, _v -> k == :x end) == 5
+      assert NestedFilter.filter("hello", fn k, _v -> k == :x end) == "hello"
+    end
+  end
+
   test "take a nested map's values by key (distinct nested keys)" do
     nested_map = %{a: %{b: 2}, c: %{d: 3, e: %{f: 4, g: %{h: %{1 => 2}}}}}
 

--- a/test/nested_filter_test.exs
+++ b/test/nested_filter_test.exs
@@ -3,28 +3,51 @@ defmodule NestedFilterTest do
   doctest NestedFilter
 
   test "can filter out a nested map's keys with nil values" do
-    nested_map = %{a: 1, b: %{m: nil, n: 2}, c: %{p: %{q: nil, r: nil}, s: %{t: 2, u: 3}} }
-    assert NestedFilter.drop_by_value(nested_map, [nil]) == %{a: 1, b: %{n: 2}, c: %{p: %{}, s: %{t: 2, u: 3}} }
+    nested_map = %{a: 1, b: %{m: nil, n: 2}, c: %{p: %{q: nil, r: nil}, s: %{t: 2, u: 3}}}
+
+    assert NestedFilter.drop_by_value(nested_map, [nil]) == %{
+             a: 1,
+             b: %{n: 2},
+             c: %{p: %{}, s: %{t: 2, u: 3}}
+           }
   end
 
   test "can filter out a nested map's keys with non-nil values" do
-    nested_map = %{a: 1, b: %{m: nil, n: 2}, c: %{p: %{q: nil, r: nil}, s: %{t: 2, u: 3}} }
-    assert NestedFilter.drop_by_value(nested_map, [2]) == %{a: 1, b: %{m: nil}, c: %{p: %{q: nil, r: nil}, s: %{u: 3}} }
+    nested_map = %{a: 1, b: %{m: nil, n: 2}, c: %{p: %{q: nil, r: nil}, s: %{t: 2, u: 3}}}
+
+    assert NestedFilter.drop_by_value(nested_map, [2]) == %{
+             a: 1,
+             b: %{m: nil},
+             c: %{p: %{q: nil, r: nil}, s: %{u: 3}}
+           }
   end
 
   test "can filter out a nested map's keys with nil and non-nil values" do
-    nested_map = %{a: 1, b: %{m: nil, n: 2}, c: %{p: %{q: nil, r: nil}, s: %{t: 2, u: 3}} }
-    assert NestedFilter.drop_by_value(nested_map, [nil, 1, 2]) == %{b: %{}, c: %{p: %{}, s: %{u: 3}} }
+    nested_map = %{a: 1, b: %{m: nil, n: 2}, c: %{p: %{q: nil, r: nil}, s: %{t: 2, u: 3}}}
+
+    assert NestedFilter.drop_by_value(nested_map, [nil, 1, 2]) == %{
+             b: %{},
+             c: %{p: %{}, s: %{u: 3}}
+           }
   end
 
   test "can filter out a nested map's keys with nil and empty map values" do
-    nested_map = %{a: 1, b: %{m: nil, n: 2}, c: %{p: %{q: nil, r: nil}, s: %{t: 2, u: 3}} }
-    assert NestedFilter.drop_by_value(nested_map, [nil, %{}]) == %{a: 1, b: %{n: 2}, c: %{s: %{t: 2, u: 3}} }
+    nested_map = %{a: 1, b: %{m: nil, n: 2}, c: %{p: %{q: nil, r: nil}, s: %{t: 2, u: 3}}}
+
+    assert NestedFilter.drop_by_value(nested_map, [nil, %{}]) == %{
+             a: 1,
+             b: %{n: 2},
+             c: %{s: %{t: 2, u: 3}}
+           }
   end
 
   test "can filter out a nested map's values by key" do
     nested_map = %{a: 1, b: %{a: 2, b: 3}, c: %{a: %{a: 1, b: 2}, b: 2, c: %{d: 1, e: 2}}}
-    assert NestedFilter.drop_by_key(nested_map, [:a]) == %{b: %{b: 3},c: %{b: 2, c: %{d: 1, e: 2}}}
+
+    assert NestedFilter.drop_by_key(nested_map, [:a]) == %{
+             b: %{b: 3},
+             c: %{b: 2, c: %{d: 1, e: 2}}
+           }
   end
 
   test "can filter out a nested map's values by multiple keys" do
@@ -33,9 +56,21 @@ defmodule NestedFilterTest do
   end
 
   test "can filter out values from a nested map with datetime structs as values" do
-    datetime = %DateTime{calendar: Calendar.ISO, day: 23, hour: 23, microsecond: {0, 0},
-      minute: 50, month: 1, second: 7, std_offset: 0, time_zone: "Etc/UTC",
-      utc_offset: 0, year: 2015, zone_abbr: "UTC"}
+    datetime = %DateTime{
+      calendar: Calendar.ISO,
+      day: 23,
+      hour: 23,
+      microsecond: {0, 0},
+      minute: 50,
+      month: 1,
+      second: 7,
+      std_offset: 0,
+      time_zone: "Etc/UTC",
+      utc_offset: 0,
+      year: 2015,
+      zone_abbr: "UTC"
+    }
+
     nested_map = %{a: 1, b: %{a: 2, b: 3}, date: datetime, foo: nil}
     assert NestedFilter.drop_by_value(nested_map, [nil, datetime]) == %{a: 1, b: %{a: 2, b: 3}}
   end
@@ -43,7 +78,12 @@ defmodule NestedFilterTest do
   test "can filter out values from a nested map with tuples as values" do
     tuple = {:ok, %{"k" => 2, "j" => 3}, 2}
     nested_map = %{a: 1, b: %{a: 2, b: 3}, tuple: tuple, foo: nil}
-    assert NestedFilter.drop_by_value(nested_map, [nil]) == %{a: 1, b: %{a: 2, b: 3}, tuple: tuple}
+
+    assert NestedFilter.drop_by_value(nested_map, [nil]) == %{
+             a: 1,
+             b: %{a: 2, b: 3},
+             tuple: tuple
+           }
   end
 
   test "can filter out lists of maps" do
@@ -54,18 +94,24 @@ defmodule NestedFilterTest do
 
   test "take a nested map's values by key (distinct nested keys)" do
     nested_map = %{a: %{b: 2}, c: %{d: 3, e: %{f: 4, g: %{h: %{1 => 2}}}}}
+
     assert NestedFilter.take_by_key(nested_map, [:b, :f, :h]) ==
-      %{b: 2, f: 4, h: %{1 => 2}}
+             %{b: 2, f: 4, h: %{1 => 2}}
   end
 
   test "take a nested map's values by key and merges map values of duplicate keys" do
     nested_map = %{a: 1, b: %{a: 2, b: 3}, c: %{a: %{a: 1, b: 2}, b: 2, c: %{d: 1, e: 2}}}
-    assert NestedFilter.take_by_key(nested_map, [:b, :c]) == %{b: %{b: 3, a: 2}, c: %{b: 2, c: %{d: 1, e: 2}, a: %{a: 1, b: 2}}}
+
+    assert NestedFilter.take_by_key(nested_map, [:b, :c]) == %{
+             b: %{b: 3, a: 2},
+             c: %{b: 2, c: %{d: 1, e: 2}, a: %{a: 1, b: 2}}
+           }
   end
 
   test "take a nested map's values by key (duplicate keys) and overwrite non-map duplicate values" do
     nested_map = %{a: %{b: 2}, c: 3, e: %{f: 4}, b: 1}
+
     assert NestedFilter.take_by_key(nested_map, [:b, :f]) ==
-      %{b: 1, f: 4 }
+             %{b: 1, f: 4}
   end
 end


### PR DESCRIPTION
## Summary

v2.0 rewrite per the approved plan (T1–T9):

- **`filter/3` / `reject/3` engines** with a shared `structs: :leaf | :convert | :error` option (default `:leaf`); `drop_by_value/3`, `drop_by_key/3`, `take_by_key/3` are now sugar over them
- **`take_by_key/3` is structure-preserving** — the 1.x flattening (and its silent data loss on duplicate keys) is gone
- **Removed** undocumented `drop_by/2` / `take_by/2`; Elixir floor raised to `~> 1.15`
- **StreamData property suite** (4 properties), 100% line coverage
- **Recipes-first README** (every snippet doctest-backed), 2.0.0 CHANGELOG with 1.x migration table
- **CI**: matrix trimmed to Elixir 1.15–1.20, new quality-gate job (format check, credo --strict, coveralls)

## Test plan

- [x] `mix test` — 12 doctests, 4 properties, 37 tests, 0 failures
- [x] `MIX_ENV=test mix coveralls` — 100.0%
- [x] `mix format --check-formatted`, `mix credo --strict` clean
- [x] `mix docs` builds without warnings
- [x] Both CI jobs green on this PR